### PR TITLE
Allow pandoc 1.12.

### DIFF
--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -17,7 +17,7 @@ library
   build-depends: base            >= 4     && < 5
                , text            >= 0.11  && < 0.12
                , bytestring      >= 0.9   && < 0.11
-               , pandoc          >= 1.10  && < 1.12
+               , pandoc          >= 1.10  && < 1.13
                , blaze-html      >= 0.5   && < 0.7
                , blaze-markup    >= 0.5   && < 0.7
                , xss-sanitize    >= 0.3.1 && < 0.4


### PR DESCRIPTION
yesod-markdown appears to build cleanly with pandoc 1.12.  Could you bump its dependency, please?
