### PR TITLE
yesod-markdown.cabal: allow text-1.0 and 1.1

### DIFF
--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -15,7 +15,7 @@ library
   exposed-modules: Yesod.Markdown
 
   build-depends: base            >= 4     && < 5
-               , text            >= 0.11  && < 0.12
+               , text            >= 0.11  && < 1.2
                , bytestring      >= 0.9   && < 0.11
                , pandoc          >= 1.10  && < 1.13
                , blaze-html      >= 0.5   && < 0.7


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
