### PR TITLE
explicit writerHighlight=True

### DIFF
--- a/Yesod/Markdown.hs
+++ b/Yesod/Markdown.hs
@@ -110,8 +110,9 @@ parseMarkdown ro = readMarkdown ro . T.unpack . unMarkdown
 -- | Defaults plus Html5, minus WrapText
 yesodDefaultWriterOptions :: WriterOptions
 yesodDefaultWriterOptions = def
-  { writerHtml5    = True
-  , writerWrapText = False
+  { writerHtml5     = True
+  , writerWrapText  = False
+  , writerHighlight = True
   }
 
 -- | Defaults plus Smart and ParseRaw

--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -1,5 +1,5 @@
 name:                yesod-markdown
-version:             0.8.2
+version:             0.8.3
 synopsis:            Tools for using markdown in a yesod application
 description:         A subset of pandoc functionality useful for markdown processing in yesod applications
 homepage:            http://github.com/pbrisbin/yesod-markdown


### PR DESCRIPTION
Because pandoc issue https://github.com/jgm/pandoc/issues/906 and Pull Request https://github.com/jgm/pandoc/pull/907 makes to prevent implicit
syntax highlighting for HTML output.

Yesod-Markdown assumes HTML output always syntax highlighting....
