### PR TITLE
update dependency for shakespeare

### DIFF
--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -24,7 +24,7 @@ library
                , directory
                , yesod-core      >= 1.2   && < 1.3
                , yesod-form      >= 1.3   && < 1.4
-               , hamlet          >= 1.1   && < 1.2
+               , shakespeare     >= 2.0   && < 2.1
                , persistent      >= 0.9
                , temporary                   < 1.2.0.2
 


### PR DESCRIPTION
According to the Hackage document for [hamlet](https://hackage.haskell.org/package/hamlet):

> Deprecated in favor of shakespeare

And yesod-bin's hsfiles is no longer using `hamlet`, `shakespeare-css`, `shakespeare-js` and `shakespeare-text` explicitly.

see: https://github.com/yesodweb/yesod/blob/master/yesod-bin/hsfiles/sqlite.hsfiles#L427
