### PR TITLE
Bump Pandoc dependency

### DIFF
--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -18,7 +18,7 @@ library
   build-depends:        base            >= 4     && < 5
                       , text            >= 0.11  && < 2.0
                       , bytestring      >= 0.9   && < 0.11
-                      , pandoc          >= 1.16  && < 1.18
+                      , pandoc          >= 1.16  && < 1.20
                       , blaze-html      >= 0.5   && < 0.9
                       , blaze-markup    >= 0.5   && < 0.8
                       , xss-sanitize    >= 0.3.1 && < 0.4


### PR DESCRIPTION
Stack lts 8.0 ships with Pandoc 1.19.2.1, which is outside our existing 
dependency graph. That means that end users that want to use this package
need to define a number of additional dependencies for their stack projects
if they wish (or need) to use 8.0.

Bumping the dependency here will allow users to simply add yesod-markdown
as a dependency, without needing to change the version of Pandoc they use.

Also removing an unused import while I'm in here mucking around.