### PR TITLE
Bump versions for blaze-html and blaze-markup.

### DIFF
--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -19,8 +19,8 @@ library
                       , text            >= 0.11  && < 2.0
                       , bytestring      >= 0.9   && < 0.11
                       , pandoc          >= 1.16  && < 1.20
-                      , blaze-html      >= 0.5   && < 0.9
-                      , blaze-markup    >= 0.5   && < 0.8
+                      , blaze-html      >= 0.5   && < 0.10
+                      , blaze-markup    >= 0.5   && < 0.9
                       , xss-sanitize    >= 0.3.1 && < 0.4
                       , directory
                       , yesod-core      >= 1.2   && < 1.5


### PR DESCRIPTION
This PR bumps versions for blaze-html and blaze-markup.

Ideally, I'd like to get yesod-markdown in stackage (https://github.com/fpco/stackage/pull/2301).  The versions of blaze-html and blaze-markup in stackage are currently greater than what yesod-markdown supports, hence the need for this PR.