### PR TITLE
Add support for pandoc-2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ dependencies:
     - "~/.stack"
     - ".stack-work"
   pre:
-    - wget https://github.com/commercialhaskell/stack/releases/download/v1.3.2/stack-1.3.2-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
-    - tar xvzOf /tmp/stack.tar.gz stack-1.3.2-linux-x86_64/stack > /tmp/stack
+    - wget https://github.com/commercialhaskell/stack/releases/download/v1.6.1/stack-1.6.1-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+    - tar xvzOf /tmp/stack.tar.gz stack-1.6.1-linux-x86_64/stack > /tmp/stack
     - chmod +x /tmp/stack && sudo mv /tmp/stack /usr/bin/stack
   override:
     - stack setup

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.0
+resolver: lts-10.0
 packages:
 - '.'
 extra-deps: []

--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -18,7 +18,7 @@ library
   build-depends:        base            >= 4     && < 5
                       , text            >= 0.11  && < 2.0
                       , bytestring      >= 0.9   && < 0.11
-                      , pandoc          >= 1.16  && < 1.20
+                      , pandoc          >= 2.0   && < 2.1
                       , blaze-html      >= 0.5   && < 0.10
                       , blaze-markup    >= 0.5   && < 0.9
                       , xss-sanitize    >= 0.3.1 && < 0.4

--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -10,6 +10,7 @@ maintainer:             Patrick Brisbin <pbrisbin@gmail.com>
 category:               Web, Yesod
 build-type:             Simple
 cabal-version:          >=1.8
+extra-source-files:     README.md
 
 library
   hs-source-dirs:       src


### PR DESCRIPTION
This PR adds a couple things:

- Support for pandoc-2.  
    - pandoc-2's API is somewhat different than pandoc-1.  The big differences affecting yesod-markdown are in the `ReaderOptions` and `WriterOptions`.  I wasn't sure exactly how `ReaderOptions` and `WriterOptions` from pandoc-1 map to `ReaderOptions` and `WriterOptions` from pandoc-2.  I played around with a couple different setups, and the current state of the code is the closest I got mapping from pandoc-1 to pandoc-2.  If someone else is more well-versed in the Pandoc source code, there may be additional options to add/enable that will make it output exactly like it did originally.
    - Another small change is the `handleError` function.  `handleError` in pandoc-1 has the following type: `Either PandocError a -> a`, while in pandoc-2 it looks like this: `Either PandocError a -> IO a`.  I've changed the yesod-markdown code to use `unsafePerformIO` with `handleError`.  This should give us the same functionality as with pandoc-1.
- Bumped the lts version to 10.0.  This uses pandoc-2.  I've also updated the version of `stack` used in the `circle.yml` file.  I believe this is necessary for using lts-10.0.
- Add a `Changelog.md` file.
- Add the `Changelog.md` file and the `README.md` file to the `.cabal` file.
- Bumped the version of yesod-markdown to 0.11.5.  This should make it easy to cut a new release.