### PR TITLE
Bumps pandoc upper bound

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ library:
   dependencies:
     - text >=0.11 && <2.0
     - bytestring >=0.9 && <0.11
-    - pandoc >=2.0 && <2.7
+    - pandoc >=2.0 && <2.8
     - blaze-html >=0.5 && <0.10
     - blaze-markup >=0.5 && <0.9
     - xss-sanitize >=0.3.1 && <0.4


### PR DESCRIPTION
This bumps the upper bound on `pandoc` to support `pandoc-2.7` (which was released today).

I've built `yesod-markdown` and run tests locally to verify that they pass.