### PR TITLE
Stop running weeder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,4 @@ jobs:
     - uses: freckle/stack-action@main
       with:
         stack-yaml: ${{ matrix.stack-yaml }}
+        weeder: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .stack-work
-*.cabal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [*Unreleased*](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.4...main)
+## [*Unreleased*](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.5...main)
 
 None
+
+## [v0.12.6.5](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.4...v0.12.6.5)
+
+- Fix incorrect dependency bounds
 
 ## [v0.12.6.4](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.3...v0.12.6.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [*Unreleased*](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.5...main)
+## [_Unreleased_](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.6.5...main)
 
 None
 
@@ -32,7 +32,8 @@ None
 
 ## [v0.12.4](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.3...v0.12.4)
 
-- Support GHC 8.4 ([@waddlaw](https://github.com/pbrisbin/yesod-markdown/pull/51))
+- Support GHC 8.4
+  ([@waddlaw](https://github.com/pbrisbin/yesod-markdown/pull/51))
 
 ## [v0.12.3](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.2...v0.12.3)
 
@@ -41,7 +42,8 @@ None
 
 ## [v0.12.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.1...v0.12.2)
 
-- Allow yesod-1.6 ([@bitemyapp](https://github.com/pbrisbin/yesod-markdown/pull/43))
+- Allow yesod-1.6
+  ([@bitemyapp](https://github.com/pbrisbin/yesod-markdown/pull/43))
 
 ## [v0.12.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.12.0...v0.12.1)
 
@@ -49,24 +51,28 @@ None
 
 ## [v0.12.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.11.4...v0.12.0)
 
-- Require pandoc-2.0, support GHC 8.2 ([@cdepillabout](https://github.com/pbrisbin/yesod-markdown/pull/40))
+- Require pandoc-2.0, support GHC 8.2
+  ([@cdepillabout](https://github.com/pbrisbin/yesod-markdown/pull/40))
 - Drop GHC 7.10 support
 
 ## [v0.11.4](https://github.com/pbrisbin/yesod-markdown/compare/v0.11.3...v0.11.4)
 
-- Allow blaze-html-0.9 and blaze-markup-0.8 ([@cdepillabout](https://github.com/pbrisbin/yesod-markdown/pull/39))
+- Allow blaze-html-0.9 and blaze-markup-0.8
+  ([@cdepillabout](https://github.com/pbrisbin/yesod-markdown/pull/39))
 
 ## [v0.11.3](https://github.com/pbrisbin/yesod-markdown/compare/v0.11.2...v0.11.3)
 
-- Allow pandoc-1.19 ([@gfontenot](https://github.com/pbrisbin/yesod-markdown/pull/37))
+- Allow pandoc-1.19
+  ([@gfontenot](https://github.com/pbrisbin/yesod-markdown/pull/37))
 
 ## [v0.11.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.11.1...v0.11.2)
 
-*No changes*
+_No changes_
 
 ## [v0.11.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.11.0...v0.11.1)
 
-- Allow pandoc-1.17 ([@andrewthad](https://github.com/pbrisbin/yesod-markdown/pull/36))
+- Allow pandoc-1.17
+  ([@andrewthad](https://github.com/pbrisbin/yesod-markdown/pull/36))
 
 ## [v0.11.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.10.0...v0.11.0)
 
@@ -74,15 +80,18 @@ None
 
 ## [v0.10.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.4...v0.10.0)
 
-- Require pandoc-1.14, support pandoc 1.15 ([@robgssp](https://github.com/pbrisbin/yesod-markdown/pull/31))
+- Require pandoc-1.14, support pandoc 1.15
+  ([@robgssp](https://github.com/pbrisbin/yesod-markdown/pull/31))
 
 ## [v0.9.4](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.3.1...v0.9.4)
 
-- Allow blaze-html-0.8 ([@geraldus](https://github.com/pbrisbin/yesod-markdown/pull/27))
+- Allow blaze-html-0.8
+  ([@geraldus](https://github.com/pbrisbin/yesod-markdown/pull/27))
 
 ## [v0.9.3.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.3...v0.9.3.1)
 
-- Correct license field ([@nkaretnikov](https://github.com/pbrisbin/yesod-markdown/pull/23))
+- Correct license field
+  ([@nkaretnikov](https://github.com/pbrisbin/yesod-markdown/pull/23))
 
 ## [v0.9.3](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.2...v0.9.3)
 
@@ -90,7 +99,8 @@ None
 
 ## [v0.9.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.1...v0.9.2)
 
-- Allow pandoc-1.13 ([cosmo0920](https://github.com/pbrisbin/yesod-markdown/pull/19))
+- Allow pandoc-1.13
+  ([cosmo0920](https://github.com/pbrisbin/yesod-markdown/pull/19))
 
 ## [v0.9.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.9.0...v0.9.1)
 
@@ -113,12 +123,15 @@ None
 
 ## [v0.8.3](https://github.com/pbrisbin/yesod-markdown/compare/v0.8.2...v0.8.3)
 
-- Allow up to text-1.1 ([@trofi](https://github.com/pbrisbin/yesod-markdown/pull/14))
-- Set `writerHighlight` ([@cosmo0920](https://github.com/pbrisbin/yesod-markdown/pull/15)))
+- Allow up to text-1.1
+  ([@trofi](https://github.com/pbrisbin/yesod-markdown/pull/14))
+- Set `writerHighlight`
+  ([@cosmo0920](https://github.com/pbrisbin/yesod-markdown/pull/15)))
 
 ## [v0.8.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.8.1...v0.8.2)
 
-- Allow pandoc-1.12 ([@cjwatson](https://github.com/pbrisbin/yesod-markdown/pull/13))
+- Allow pandoc-1.12
+  ([@cjwatson](https://github.com/pbrisbin/yesod-markdown/pull/13))
 
 ## [v0.8.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.8.0...v0.8.1)
 
@@ -126,11 +139,13 @@ None
 
 ## [v0.8.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.7.2...v0.8.0)
 
-- Support yesod-1.2 ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/12))
+- Support yesod-1.2
+  ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/12))
 
 ## [v0.7.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.7.1...v0.7.2)
 
-- Support yesod-1.1 ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/11))
+- Support yesod-1.1
+  ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/11))
 
 ## [v0.7.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.7...v0.7.1)
 
@@ -146,16 +161,20 @@ None
 
 ## [v0.5.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.5.0...v0.5.1)
 
-- Allow newer persistent ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/9))
+- Allow newer persistent
+  ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/9))
 
 ## [v0.5.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.4.1...v0.5.0)
 
-- Require yesod-1.1 and yesod-form-1.2 ([@dlthomas](https://github.com/pbrisbin/yesod-markdown/pull/7))
+- Require yesod-1.1 and yesod-form-1.2
+  ([@dlthomas](https://github.com/pbrisbin/yesod-markdown/pull/7))
 
 ## [v0.4.1](https://github.com/pbrisbin/yesod-markdown/compare/v0.4.0...v0.4.1)
 
-- Require blaze-html 0.5 ([@lbolla](https://github.com/pbrisbin/yesod-markdown/pull/5))
-- Allow yesod-1.1 ([@SimSaladin](https://github.com/pbrisbin/yesod-markdown/pull/6))
+- Require blaze-html 0.5
+  ([@lbolla](https://github.com/pbrisbin/yesod-markdown/pull/5))
+- Allow yesod-1.1
+  ([@SimSaladin](https://github.com/pbrisbin/yesod-markdown/pull/6))
 
 ## [v0.4.0](https://github.com/pbrisbin/yesod-markdown/compare/v0.3.4...v0.4.0)
 
@@ -163,11 +182,13 @@ None
 
 ## [v0.3.4](https://github.com/pbrisbin/yesod-markdown/compare/v0.3.3...v0.3.4)
 
-- Drop GHC 6 support ([@pSub](https://github.com/pbrisbin/yesod-markdown/pull/2))
+- Drop GHC 6 support
+  ([@pSub](https://github.com/pbrisbin/yesod-markdown/pull/2))
 
 ## [v0.3.3](https://github.com/pbrisbin/yesod-markdown/compare/v0.3.2...v0.3.3)
 
-- Break up yesod dependency ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/1))
+- Break up yesod dependency
+  ([@gregwebs](https://github.com/pbrisbin/yesod-markdown/pull/1))
 
 ## [v0.3.2](https://github.com/pbrisbin/yesod-markdown/compare/v0.3.1...v0.3.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yesod-markdown
-version: 0.12.6.4
+version: 0.12.6.5
 synopsis: Tools for using markdown in a yesod application
 description: >
   A subset of Pandoc functionality useful for markdown processing in yesod
@@ -16,23 +16,23 @@ extra-source-files:
 
 dependencies:
   - base >=4.8.0 && <5
+  - blaze-html >=0.5 && <0.10
+  - text >=0.11 && <2.0
 
 ghc-options: -Wall
 
 library:
   source-dirs: src
   dependencies:
-    - text >=0.11 && <2.0
     - bytestring >=0.9 && <0.12
     - pandoc >=2.0 && <2.12
-    - blaze-html >=0.5 && <0.10
     - blaze-markup >=0.5 && <0.9
     - xss-sanitize >=0.3.1 && <0.4
-    - directory
+    - directory < 1.4
     - yesod-core >=1.2 && <1.7
     - yesod-form >=1.3 && <1.7
     - shakespeare >=2.0 && <2.1
-    - persistent >=0.9
+    - persistent >=0.9 && < 2.12
 
 tests:
   test:
@@ -42,5 +42,3 @@ tests:
     dependencies:
       - yesod-markdown
       - hspec
-      - blaze-html
-      - text

--- a/stack-lts-12.10.yaml
+++ b/stack-lts-12.10.yaml
@@ -1,4 +1,1 @@
 resolver: lts-12.10
-
-# Fix weeder with stack-2.0
-ghc-options: { "$locals": -ddump-to-file -ddump-hi }

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,4 +1,1 @@
 resolver: lts-14.27
-
-# Fix weeder with stack-2.0
-ghc-options: { "$locals": -ddump-to-file -ddump-hi }

--- a/stack-lts-15.12.yaml
+++ b/stack-lts-15.12.yaml
@@ -1,4 +1,1 @@
 resolver: lts-15.12
-
-# Fix weeder with stack-2.0
-ghc-options: { "$locals": -ddump-to-file -ddump-hi }

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,5 +1,2 @@
 # Date of last update, overridden on CI with --resolver
 resolver: nightly-2020-05-15
-
-# Fix weeder with stack-2.0
-ghc-options: { "$locals": -ddump-to-file -ddump-hi }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
 resolver: lts-15.12
-
-# Fix weeder with stack-2.0
-ghc-options: { "$locals": -ddump-to-file -ddump-hi }

--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -1,0 +1,66 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 48d358071c68516b961faf8354b3cc06b3ed2e7733e1e74f25dd4af851e63774
+
+name:           yesod-markdown
+version:        0.12.6.4
+synopsis:       Tools for using markdown in a yesod application
+description:    A subset of Pandoc functionality useful for markdown processing in yesod applications
+category:       Web, Yesod
+homepage:       http://github.com/pbrisbin/yesod-markdown
+bug-reports:    https://github.com/pbrisbin/yesod-markdown/issues
+author:         Alexander Dunlap, Patrick Brisbin
+maintainer:     Patrick Brisbin <pbrisbin@gmail.com>
+license:        GPL-2
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/pbrisbin/yesod-markdown
+
+library
+  exposed-modules:
+      Yesod.Markdown
+  other-modules:
+      Paths_yesod_markdown
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.8.0 && <5
+    , blaze-html >=0.5 && <0.10
+    , blaze-markup >=0.5 && <0.9
+    , bytestring >=0.9 && <0.12
+    , directory
+    , pandoc >=2.0 && <2.12
+    , persistent >=0.9
+    , shakespeare >=2.0 && <2.1
+    , text >=0.11 && <2.0
+    , xss-sanitize >=0.3.1 && <0.4
+    , yesod-core >=1.2 && <1.7
+    , yesod-form >=1.3 && <1.7
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_yesod_markdown
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -threaded
+  build-depends:
+      base >=4.8.0 && <5
+    , blaze-html
+    , hspec
+    , text
+    , yesod-markdown
+  default-language: Haskell2010

--- a/yesod-markdown.cabal
+++ b/yesod-markdown.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 48d358071c68516b961faf8354b3cc06b3ed2e7733e1e74f25dd4af851e63774
+-- hash: eecead7193986e2a670e31176880877c75ae6ca659129be5f046a6c5c6bc6742
 
 name:           yesod-markdown
-version:        0.12.6.4
+version:        0.12.6.5
 synopsis:       Tools for using markdown in a yesod application
 description:    A subset of Pandoc functionality useful for markdown processing in yesod applications
 category:       Web, Yesod
@@ -39,9 +39,9 @@ library
     , blaze-html >=0.5 && <0.10
     , blaze-markup >=0.5 && <0.9
     , bytestring >=0.9 && <0.12
-    , directory
+    , directory <1.4
     , pandoc >=2.0 && <2.12
-    , persistent >=0.9
+    , persistent >=0.9 && <2.12
     , shakespeare >=2.0 && <2.1
     , text >=0.11 && <2.0
     , xss-sanitize >=0.3.1 && <0.4
@@ -59,8 +59,8 @@ test-suite test
   ghc-options: -Wall -threaded
   build-depends:
       base >=4.8.0 && <5
-    , blaze-html
+    , blaze-html >=0.5 && <0.10
     , hspec
-    , text
+    , text >=0.11 && <2.0
     , yesod-markdown
   default-language: Haskell2010


### PR DESCRIPTION
Weeder-2.0 removes the extra dependencies feature (and improves the dead code
elimination feature). In a library, the new dead-code behavior isn't great,
since you tend to have wide public interface of "roots". We were using
Weeder-1.0 mostly for the extra dependencies feature, which is now part of GHC
(or Cabal) as of 8.10.